### PR TITLE
Update lesson for css flex for minor correction

### DIFF
--- a/lessons/03-css/E-flex.md
+++ b/lessons/03-css/E-flex.md
@@ -222,7 +222,7 @@ Vertically centering something previous to flex was a nightmare. Seriously, Goog
 
   /* remove the height from the three boxes */
   .no-height {
-    height: inherit;
+    height: unset;
   }
 </style>
 <div class="flex-container ai-stretch">


### PR DESCRIPTION
On line 225, height: unset; instead of height: inherit;
Using inherit would make the use of align-items: stretch; redundant, unset to actually remove the height property.