### PR TITLE
fix: prevent overflow in .klipse-result children by enabling word bre…

### DIFF
--- a/styles/courses.css
+++ b/styles/courses.css
@@ -233,7 +233,7 @@ header .cta-btn {
   text-decoration: underline;
 }
 
-.lesson a:hover, 
+.lesson a:hover,
 .lesson a:active {
   text-decoration: none;
 }
@@ -258,7 +258,9 @@ header .cta-btn {
   max-width: 300px;
 }
 
-.lesson p, .lesson ul, .lesson ol {
+.lesson p,
+.lesson ul,
+.lesson ol {
   clear: both;
   margin-bottom: 20px;
 }
@@ -523,7 +525,7 @@ ol.sections-name .lesson-details {
   margin-left: 15px;
 }
 
-.lesson li { 
+.lesson li {
   margin-left: 40px;
 }
 
@@ -565,6 +567,13 @@ ol.sections-name .lesson-details {
 
 .klipse-result li {
   list-style-position: inside;
+}
+
+/* overflow content handling in klipse-result */
+.klipse-result > * {
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .support-tweet {


### PR DESCRIPTION
…aking

Applied CSS to ensure code and content inside .klipse-result does not overflow horizontally. Long words will now break and wrap appropriately.

Styles added:
- overflow-x: auto
- white-space: pre-wrap
- word-break: break-all

This improves readability of code output and prevents layout issues in dynamic environments like Klipse.